### PR TITLE
Move to Babel 7

### DIFF
--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -192,7 +192,9 @@ describe('ReactFunctionComponent', () => {
       ReactTestUtils.renderIntoDocument(<ParentUsingStringRef />),
     ).toWarnDev(
       'Warning: Function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.\n\nCheck the render method ' +
+        'Attempts to access this ref will fail. ' +
+        'Did you mean to use React.forwardRef()?\n\n' +
+        'Check the render method ' +
         'of `ParentUsingStringRef`.\n' +
         '    in FunctionComponent (at **)\n' +
         '    in div (at **)\n' +
@@ -228,7 +230,9 @@ describe('ReactFunctionComponent', () => {
       ReactTestUtils.renderIntoDocument(<ParentUsingFunctionRef />),
     ).toWarnDev(
       'Warning: Function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.\n\nCheck the render method ' +
+        'Attempts to access this ref will fail. ' +
+        'Did you mean to use React.forwardRef()?\n\n' +
+        'Check the render method ' +
         'of `ParentUsingFunctionRef`.\n' +
         '    in FunctionComponent (at **)\n' +
         '    in div (at **)\n' +
@@ -332,7 +336,9 @@ describe('ReactFunctionComponent', () => {
 
     expect(() => ReactTestUtils.renderIntoDocument(<Parent />)).toWarnDev(
       'Warning: Function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.\n\nCheck the render method ' +
+        'Attempts to access this ref will fail. ' +
+        'Did you mean to use React.forwardRef()?\n\n' +
+        'Check the render method ' +
         'of `Parent`.\n' +
         '    in Child (at **)\n' +
         '    in Parent (at **)',

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -138,7 +138,8 @@ function coerceRef(
         const ownerFiber = ((owner: any): Fiber);
         invariant(
           ownerFiber.tag === ClassComponent,
-          'Function components cannot have refs.',
+          'Function components cannot have refs. ' +
+            'Did you mean to use React.forwardRef()?',
         );
         inst = ownerFiber.stateNode;
       }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1293,7 +1293,8 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
       warning(
         false,
         'Function components cannot be given refs. ' +
-          'Attempts to access this ref will fail.%s',
+          'Attempts to access this ref will fail. ' +
+          'Did you mean to use React.forwardRef()?%s',
         info,
       );
     }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -984,6 +984,9 @@ function mountLazyComponent(
   let child;
   switch (resolvedTag) {
     case FunctionComponent: {
+      if (__DEV__) {
+        validateFunctionComponentInDev(workInProgress, Component);
+      }
       child = updateFunctionComponent(
         null,
         workInProgress,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -250,6 +250,23 @@ function updateForwardRef(
       ref,
       renderExpirationTime,
     );
+    if (
+      debugRenderPhaseSideEffects ||
+      (debugRenderPhaseSideEffectsForStrictMode &&
+        workInProgress.mode & StrictMode)
+    ) {
+      // Only double-render components with Hooks
+      if (workInProgress.memoizedState !== null) {
+        renderWithHooks(
+          current,
+          workInProgress,
+          render,
+          nextProps,
+          ref,
+          renderExpirationTime,
+        );
+      }
+    }
     setCurrentPhase(null);
   } else {
     nextChildren = renderWithHooks(
@@ -543,6 +560,23 @@ function updateFunctionComponent(
       context,
       renderExpirationTime,
     );
+    if (
+      debugRenderPhaseSideEffects ||
+      (debugRenderPhaseSideEffectsForStrictMode &&
+        workInProgress.mode & StrictMode)
+    ) {
+      // Only double-render components with Hooks
+      if (workInProgress.memoizedState !== null) {
+        renderWithHooks(
+          current,
+          workInProgress,
+          Component,
+          nextProps,
+          context,
+          renderExpirationTime,
+        );
+      }
+    }
     setCurrentPhase(null);
   } else {
     nextChildren = renderWithHooks(
@@ -1207,6 +1241,25 @@ function mountIndeterminateComponent(
   } else {
     // Proceed under the assumption that this is a function component
     workInProgress.tag = FunctionComponent;
+    if (__DEV__) {
+      if (
+        debugRenderPhaseSideEffects ||
+        (debugRenderPhaseSideEffectsForStrictMode &&
+          workInProgress.mode & StrictMode)
+      ) {
+        // Only double-render components with Hooks
+        if (workInProgress.memoizedState !== null) {
+          renderWithHooks(
+            null,
+            workInProgress,
+            Component,
+            props,
+            context,
+            renderExpirationTime,
+          );
+        }
+      }
+    }
     reconcileChildren(null, workInProgress, value, renderExpirationTime);
     if (__DEV__) {
       validateFunctionComponentInDev(workInProgress, Component);

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-present, Facebook, Inc.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root direcreatey of this source tree.
+ * LICENSE file in the root directory of this source tree.
  *
  * @flow
  */

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -72,7 +72,7 @@ if (__DEV__) {
   ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings = () => {
     ((pendingUnsafeLifecycleWarnings: any): FiberToLifecycleMap).forEach(
       (lifecycleWarningsMap, strictRoot) => {
-        const lifecyclesWarningMesages = [];
+        const lifecyclesWarningMessages = [];
 
         Object.keys(lifecycleWarningsMap).forEach(lifecycle => {
           const lifecycleWarnings = lifecycleWarningsMap[lifecycle];
@@ -87,14 +87,14 @@ if (__DEV__) {
             const suggestion = LIFECYCLE_SUGGESTIONS[lifecycle];
             const sortedComponentNames = setToSortedString(componentNames);
 
-            lifecyclesWarningMesages.push(
+            lifecyclesWarningMessages.push(
               `${formatted}: Please update the following components to use ` +
                 `${suggestion} instead: ${sortedComponentNames}`,
             );
           }
         });
 
-        if (lifecyclesWarningMesages.length > 0) {
+        if (lifecyclesWarningMessages.length > 0) {
           const strictRootComponentStack = getStackByFiberInDevAndProd(
             strictRoot,
           );
@@ -106,7 +106,7 @@ if (__DEV__) {
               '\n\nLearn more about this warning here:' +
               '\nhttps://fb.me/react-strict-mode-warnings',
             strictRootComponentStack,
-            lifecyclesWarningMesages.join('\n\n'),
+            lifecyclesWarningMessages.join('\n\n'),
           );
         }
       },

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -660,4 +660,224 @@ describe('ReactHooks', () => {
       'Hooks can only be called inside the body of a function component',
     );
   });
+
+  it('double-invokes components with Hooks in Strict Mode', () => {
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = true;
+
+    const {useState, StrictMode} = React;
+    let renderCount = 0;
+
+    function NoHooks() {
+      renderCount++;
+      return <div />;
+    }
+
+    function HasHooks() {
+      useState(0);
+      renderCount++;
+      return <div />;
+    }
+
+    const FwdRef = React.forwardRef((props, ref) => {
+      renderCount++;
+      return <div />;
+    });
+
+    const FwdRefHasHooks = React.forwardRef((props, ref) => {
+      useState(0);
+      renderCount++;
+      return <div />;
+    });
+
+    const Memo = React.memo(props => {
+      renderCount++;
+      return <div />;
+    });
+
+    const MemoHasHooks = React.memo(props => {
+      useState(0);
+      renderCount++;
+      return <div />;
+    });
+
+    function Factory() {
+      return {
+        state: {},
+        render() {
+          renderCount++;
+          return <div />;
+        },
+      };
+    }
+
+    let renderer = ReactTestRenderer.create(null);
+
+    renderCount = 0;
+    renderer.update(<NoHooks />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(<NoHooks />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <NoHooks />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <NoHooks />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(1);
+
+    renderCount = 0;
+    renderer.update(<FwdRef />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(<FwdRef />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <FwdRef />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <FwdRef />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(1);
+
+    renderCount = 0;
+    renderer.update(<Memo arg={1} />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(<Memo arg={2} />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <Memo arg={1} />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <Memo arg={2} />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(1);
+
+    renderCount = 0;
+    renderer.update(<Factory />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(<Factory />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <Factory />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(__DEV__ ? 2 : 1); // Treated like a class
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <Factory />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(__DEV__ ? 2 : 1); // Treated like a class
+
+    renderCount = 0;
+    renderer.update(<HasHooks />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(<HasHooks />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <HasHooks />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(__DEV__ ? 2 : 1); // Has Hooks
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <HasHooks />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(__DEV__ ? 2 : 1); // Has Hooks
+
+    renderCount = 0;
+    renderer.update(<FwdRefHasHooks />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(<FwdRefHasHooks />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <FwdRefHasHooks />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(__DEV__ ? 2 : 1); // Has Hooks
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <FwdRefHasHooks />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(__DEV__ ? 2 : 1); // Has Hooks
+
+    renderCount = 0;
+    renderer.update(<MemoHasHooks arg={1} />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(<MemoHasHooks arg={2} />);
+    expect(renderCount).toBe(1);
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <MemoHasHooks arg={1} />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(__DEV__ ? 2 : 1); // Has Hooks
+    renderCount = 0;
+    renderer.update(
+      <StrictMode>
+        <MemoHasHooks arg={2} />
+      </StrictMode>,
+    );
+    expect(renderCount).toBe(__DEV__ ? 2 : 1); // Has Hooks
+  });
+
+  it('double-invokes useMemo in DEV StrictMode despite []', () => {
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = true;
+    const {useMemo, StrictMode} = React;
+
+    let useMemoCount = 0;
+    function BadUseMemo() {
+      useMemo(() => {
+        useMemoCount++;
+      }, []);
+      return <div />;
+    }
+
+    useMemoCount = 0;
+    ReactTestRenderer.create(
+      <StrictMode>
+        <BadUseMemo />
+      </StrictMode>,
+    );
+    expect(useMemoCount).toBe(__DEV__ ? 2 : 1); // Has Hooks
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -1202,7 +1202,9 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.render(<Foo show={true} />);
     expect(ReactNoop.flush).toWarnDev(
       'Warning: Function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.\n\nCheck the render method ' +
+        'Attempts to access this ref will fail. ' +
+        'Did you mean to use React.forwardRef()?\n\n' +
+        'Check the render method ' +
         'of `Foo`.\n' +
         '    in FunctionComponent (at **)\n' +
         '    in div (at **)\n' +

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -1064,4 +1064,28 @@ describe('ReactLazy', () => {
     root.unstable_flushAll();
     expect(root).toMatchRenderedOutput('2');
   });
+
+  it('warns about ref on functions for lazy-loaded components', async () => {
+    const LazyFoo = lazy(() => {
+      const Foo = props => <div />;
+      return fakeImport(Foo);
+    });
+
+    const ref = React.createRef();
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyFoo ref={ref} />
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    expect(root).toFlushAndYield(['Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+    await Promise.resolve();
+    expect(() => {
+      expect(root).toFlushAndYield([]);
+    }).toWarnDev('Function components cannot be given refs');
+  });
 });

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -282,7 +282,9 @@ describe('ReactTestRenderer', () => {
     ReactTestRenderer.create(<Baz />);
     expect(() => ReactTestRenderer.create(<Foo />)).toWarnDev(
       'Warning: Function components cannot be given refs. Attempts ' +
-        'to access this ref will fail.\n\nCheck the render method of `Foo`.\n' +
+        'to access this ref will fail. ' +
+        'Did you mean to use React.forwardRef()?\n\n' +
+        'Check the render method of `Foo`.\n' +
         '    in Bar (at **)\n' +
         '    in Foo (at **)',
     );

--- a/scripts/babel/__tests__/wrap-warning-with-env-check-test.js
+++ b/scripts/babel/__tests__/wrap-warning-with-env-check-test.js
@@ -7,7 +7,7 @@
 /* eslint-disable quotes */
 'use strict';
 
-let babel = require('babel-core');
+let babel = require('@babel/core');
 let wrapWarningWithEnvCheck = require('../wrap-warning-with-env-check');
 
 const filename = 'wrap-warning-with-env-check-test.js';

--- a/scripts/error-codes/__tests__/replace-invariant-error-codes-test.js
+++ b/scripts/error-codes/__tests__/replace-invariant-error-codes-test.js
@@ -7,7 +7,7 @@
 /* eslint-disable quotes */
 'use strict';
 
-let babel = require('babel-core');
+let babel = require('@babel/core');
 let devExpressionWithCodes = require('../replace-invariant-error-codes');
 
 const filename = 'replace-invariant-error-codes-test.js';

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 
-const babel = require('babel-core');
+const babel = require('@babel/core');
 const coffee = require('coffee-script');
 
 const tsPreprocessor = require('./typescript/preprocessor');
@@ -10,7 +10,8 @@ const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction
 
 // Use require.resolve to be resilient to file moves, npm updates, etc
 const pathToBabel = path.join(
-  require.resolve('babel-core'),
+  require.resolve('@babel/core'),
+  '..',
   '..',
   'package.json'
 );

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -353,7 +353,7 @@ const bundles = [
     babel: opts =>
       Object.assign({}, opts, {
         plugins: opts.plugins.concat([
-          require.resolve('babel-plugin-transform-regenerator'),
+          require.resolve('@babel/plugin-transform-regenerator'),
         ]),
       }),
   },


### PR DESCRIPTION
I'm starting to migrate everything to Babel 7. For now `yarn test` passes but `yarn test-prod` doesn't because it gives me `_prodInvariant is not defined`.

`_prodInvariant` is a variable that gets created in `scripts/error-codes/replace-invariant-error-codes.js`.

Besides, i think we have to upgrade `rollup` because `rollup-plugin-babel` now requires at least version `0.60.0` while we are still on `0.52.1`.

Right now i'm trying to resolve the `_prodInvariant` thing.